### PR TITLE
Fixes #1: Use curly rather than square brackets in processing to avoid shortcode conflict

### DIFF
--- a/preserve-code-formatting.php
+++ b/preserve-code-formatting.php
@@ -266,11 +266,11 @@ final class c2c_PreserveCodeFormatting extends c2c_PreserveCodeFormatting_Plugin
 
 			foreach ( $codes as $code ) {
 				if ( preg_match( "/^<({$tag}[^>]*)>(.*)<\\/{$tag}>/Us", $code, $match ) ) {
-					$code = "[[{$match[1]}]]";
+					$code = "{{{$match[1]}}}";
 					// Note: base64_encode is only being used to encode user-supplied content of code tags which
 					// will be decoded later in the filtering process to prevent modification by WP.
 					$code .= base64_encode( addslashes( chunk_split( serialize( $match[2] ), 76, $this->chunk_split_token ) ) );
-					$code .= "[[/{$tag}]]";
+					$code .= "{{/{$tag}}}";
 				}
 				$result .= $code;
 			}
@@ -298,10 +298,10 @@ final class c2c_PreserveCodeFormatting extends c2c_PreserveCodeFormatting_Plugin
 				$result = '';
 			}
 
-			$codes = preg_split( "/(\\[\\[{$tag}[^\\]]*\\]\\].*\\[\\[\\/{$tag}\\]\\])/Us", $content, -1, PREG_SPLIT_DELIM_CAPTURE );
+			$codes = preg_split( "/(\\{\\{{$tag}[^\\]]*\\}\\}.*\\{\\{\\/{$tag}\\}\\})/Us", $content, -1, PREG_SPLIT_DELIM_CAPTURE );
 
 			foreach ( $codes as $code ) {
-				if ( preg_match( "/\\[\\[({$tag}[^\\]]*)\\]\\](.*)\\[\\[\\/{$tag}\\]\\]/Us", $code, $match ) ) {
+				if ( preg_match( "/\\{\\{({$tag}[^\\]]*)\\}\\}(.*)\\{\\{\\/{$tag}\\}\\}/Us", $code, $match ) ) {
 					// Note: base64_decode is only being used to decode user-supplied content of code tags which
 					// had been encoded earlier in the filtering process to prevent modification by WP.
 					$data = unserialize( str_replace( $this->chunk_split_token, '', stripslashes( base64_decode( $match[2] ) ) ) );


### PR DESCRIPTION
Curly brackets themselves may present other challenges, since they're a PHP thing -- if there's another character you'd prefer then would work just as well.